### PR TITLE
fix header parser regex

### DIFF
--- a/request/header.awk
+++ b/request/header.awk
@@ -1,9 +1,6 @@
 @namespace "request"
 
-function parse_headers(req_reader, headers,    previous_fs) {
-    previous_fs = FS
-    FS = ": +"
-
+function parse_headers(req_reader, headers) {
     delete headers
     while ((req_reader |& getline) > 0) {
         if (!$0) {
@@ -11,8 +8,9 @@ function parse_headers(req_reader, headers,    previous_fs) {
             break
         }
 
-        headers[$1] = $2
+        # separate by ":"
+        # NOTE: FS cannot be used (otherwise, value like "localhost:8000" is torn!)
+        match($0, ": *")
+        headers[substr($0, 1, RSTART - 1)] = substr($0, RSTART + RLENGTH)
     }
-
-    FS = previous_fs
 }

--- a/request/header_test.awk
+++ b/request/header_test.awk
@@ -41,6 +41,10 @@ function test_parse_headers(    tests, f) {
     tests[4]["expected"][""] = ""
     delete tests[4]["expected"][""]
 
+    tests[5]["title"] = "without space after :"
+    tests[5]["fixturename"] = "header_without_space.txt"
+    tests[5]["expected"]["Host"] = "localhost:8080"
+
     for (i in tests) {
         f = test::setup_fixture(tests[i]["fixturename"])
 

--- a/request/testdata/header_without_space.txt
+++ b/request/testdata/header_without_space.txt
@@ -1,0 +1,1 @@
+Host:localhost:8080


### PR DESCRIPTION
allow request header without spaces like `Content-Type:application/json`