### PR TITLE
Add custom headers

### DIFF
--- a/functions.awk
+++ b/functions.awk
@@ -1,6 +1,7 @@
 @include "server/request.awk"
 @include "server/reset.awk"
 @include "server/response.awk"
+@include "util/time.awk"
 
 # return wether request method is POST with end-point path_template
 function POST(path_template) {
@@ -66,8 +67,10 @@ function body(query) {
 }
 
 # send back response
-function res(statuscode, v,   res_str) {
-    res_str = server::respond(statuscode, v)
+function res(statuscode, v, headers,   res_str) {
+    headers["Date"] = util::format_time(systime())
+
+    res_str = server::respond(statuscode, v, headers)
     # NOTE: use printf not to add trailing \n
     printf res_str |& http_service()
     close(http_service())

--- a/server/response.awk
+++ b/server/response.awk
@@ -4,7 +4,7 @@
 @include "response/response.awk"
 @include "server/globalvars.awk"
 
-function respond(statuscode, body,    headers, json_str) {
+function respond(statuscode, body, headers,    json_str) {
     headers["Connection"] = "keep-alive"
 
     json_str = json::marshal(body)

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# NOTE: this must be set, otherwise Date header might not be encoded in English
+export LC_ALL=c
+
 for testfile in $(find ./ -name "*_test.awk" -type f); do
     echo $testfile
     gawk -f $testfile

--- a/util/time.awk
+++ b/util/time.awk
@@ -1,0 +1,11 @@
+@namespace "util"
+
+# NOTE: define only generally-used helper functions in util! (not specific ones)
+
+function format_time(timestamp) {
+    # this follows RFC7231 date format
+    # NOTE: "LC_ALL=c" must be set, otherwise strftime might encode time in other languages
+
+    uses_utc = 1 # true
+    return awk::strftime("%a, %d %b %Y %H:%M:%S %Z", timestamp, uses_utc)
+}

--- a/util/time_test.awk
+++ b/util/time_test.awk
@@ -1,0 +1,39 @@
+@include "util/time.awk"
+
+BEGIN {
+    err = test_format_time()
+    if (err) {
+        print err
+        exit 1
+    }
+
+    print "passed"
+}
+
+function test_format_time(    tests, log_prefix) {
+    uses_utc = 1 # true
+
+    tests[1]["title"]    = "time 2021 May 7 12:34:56"
+    #                              yyyy mm dd hh mm ss
+    tests[1]["input"]    = mktime("2021 05 07 12 34 56", uses_utc)
+    tests[1]["expected"] = "Fri, 07 May 2021 12:34:56 GMT"
+
+    for (i in tests) {
+        err = _test_format_time(tests[i])
+        if (err) {
+            return "test_format_time: " err
+        }
+    }
+}
+
+function _test_format_time(tc,    log_prefix, actual) {
+    log_prefix = sprintf("case '%s'", tc["title"])
+    actual = util::format_time(tc["input"])
+
+    if (actual != tc["expected"]) {
+        return sprintf("%s: result must be '%s'. got='%s'",
+            log_prefix, tc["expected"], actual)
+    }
+
+    return ""
+}

--- a/webawk.sh
+++ b/webawk.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # NOTE: this must be set, otherwise Date header might not be encoded in English
-export LC_ALL=c
+export LC_ALL=c 2>/dev/null
 
 print_help() {
     echo "-f progfile : run program file instead of program string"

--- a/webawk.sh
+++ b/webawk.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# NOTE: this must be set, otherwise Date header might not be encoded in English
+export LC_ALL=c
+
 print_help() {
     echo "-f progfile : run program file instead of program string"
     echo "-h          : get help"


### PR DESCRIPTION
- enable to set custom response headers
- add Date header following RFC7231

```bash
$ curl -i localhost:8080/names
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 18
Content-Type: application/json
Date: Fri, 07 May 2021 02:13:32 GMT

{"names":["Taro"]}
```