### PR TITLE
add header()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ See https://github.com/users/Syuparn/packages/container/package/webawk for detai
 
 See `./examples` for practical examples.
 You can also check command options by `./webawk.sh -h`.
+
+# For developers
+
+```bash
+# test
+$ ./test.sh
+```

--- a/example/request_header.awk
+++ b/example/request_header.awk
@@ -1,0 +1,1 @@
+GET("/request-ids") { b["request_id"]=header("request-id"); res(200, b) }

--- a/functions.awk
+++ b/functions.awk
@@ -60,6 +60,11 @@ function getquery(key, queries) {
     return server::find_query(key, queries)
 }
 
+# find header from received request headers
+function header(key) {
+    return server::find_header(key)
+}
+
 # find element from received request body
 # NOTE: query must be jq-style (this internally used jq)
 function body(query) {

--- a/server/request.awk
+++ b/server/request.awk
@@ -87,6 +87,15 @@ function find_query(key, queries) {
     }
 }
 
+
+function find_header(key) {
+    # NOTE: if key is referred directly, empty value is assigned implicitly
+    if (key in awk::REQUEST_HEADERS) {
+        return awk::REQUEST_HEADERS[key]
+    }
+    return ""
+}
+
 function find_body(query,    result) {
     result = json::jq(awk::REQUEST_BODY, query)
     if (result == "null") {

--- a/server/request_test.awk
+++ b/server/request_test.awk
@@ -52,6 +52,16 @@ BEGIN {
         print err
         exit 1
     }
+    err = test_find_header_found()
+    if (err) {
+        print err
+        exit 1
+    }
+    err = test_find_header_not_found()
+    if (err) {
+        print err
+        exit 1
+    }
     err = test_find_body()
     if (err) {
         print err
@@ -510,6 +520,51 @@ function _test_find_query(tc,     actual, i){
             return sprintf("%s: queries[%d] must be '%s'. got='%s'",
                 log_prefix, i, tc["expected"][i], actual[i])
         }
+    }
+
+    return ""
+}
+
+function test_find_header_found(    tests, err) {
+    tests[1]["title"]    = "found"
+    tests[1]["key"]      = "Content-Type"
+    tests[1]["expected"] = "application/json"
+
+    for (i in tests) {
+        # got pathparams
+        REQUEST_HEADERS["Content-Type"] = "application/json"
+
+        err = _test_find_header(tests[i], f)
+        # NOTE: global variables must be reset
+        test::reset_globals()
+        if (err) {
+            return "test_find_header_found: " err
+        }
+    }
+}
+
+function test_find_header_not_found(    tests, err) {
+    tests[1]["title"]    = "not found"
+    tests[1]["key"]      = "name"
+    tests[1]["expected"] = ""
+
+    for (i in tests) {
+        err = _test_find_header(tests[i])
+        # NOTE: global variables must be reset
+        test::reset_globals()
+        if (err) {
+            return "test_find_header_not_found: " err
+        }
+    }
+}
+
+function _test_find_header(tc,    log_prefix, actual) {
+    log_prefix = sprintf("case '%s'", tc["title"])
+    actual = server::find_header(tc["key"])
+
+    if (actual != tc["expected"]) {
+        return sprintf("%s: result must be '%s'. got='%s'",
+            log_prefix, tc["expected"], actual)
     }
 
     return ""


### PR DESCRIPTION
add function `header()` to get request headers

```awk
GET("/request-ids") { b["request_id"]=header("request-id"); res(200, b) }
```

```bash
$ curl localhost:8080/request-ids -H 'request-id: foo'
{"request_id":"foo"}
```